### PR TITLE
don't depend on godeps for finding dependencies

### DIFF
--- a/anderson/classifier.go
+++ b/anderson/classifier.go
@@ -16,10 +16,9 @@ type LicenseClassifier struct {
 	Config Config
 }
 
-func (c LicenseClassifier) Classify(path string, importPath string) (LicenseStatus, string, error) {
+func (c LicenseClassifier) Classify(path string, importPath string) (LicenseStatus, string, string, error) {
 	for hops := 0; hops < maxParentHops; hops++ {
 		newPath := c.parentPath(path, hops)
-
 		if c.pathIsAGopath(newPath) {
 			break
 		}
@@ -27,11 +26,11 @@ func (c LicenseClassifier) Classify(path string, importPath string) (LicenseStat
 		status, licenseType, err := c.classifyPath(newPath, importPath)
 
 		if status != LicenseTypeNoLicense {
-			return status, licenseType, err
+			return status, newPath, licenseType, err
 		}
 	}
 
-	return LicenseTypeNoLicense, "Unknown", nil
+	return LicenseTypeNoLicense, path, "Unknown", nil
 }
 
 func (c LicenseClassifier) classifyPath(path string, importPath string) (LicenseStatus, string, error) {

--- a/anderson/gopath.go
+++ b/anderson/gopath.go
@@ -38,6 +38,26 @@ func LookGopath(packagePath string) (string, error) {
 	return "", errors.New("could not find package in GOPATH")
 }
 
+func ContainingGopath(packagePath string) (string, error) {
+	paths, err := Gopaths()
+	if err != nil {
+		return "", err
+	}
+
+	for _, dir := range paths {
+		if dir == "" {
+			// Unix shell semantics: path element "" means "."
+			dir = "."
+		}
+		path := filepath.Join(dir, "src", packagePath)
+		if err := findPackage(path); err == nil {
+			return dir, nil
+		}
+	}
+
+	return "", errors.New("could not find package in GOPATH")
+}
+
 func Gopaths() ([]string, error) {
 	gopathenv := os.Getenv("GOPATH")
 	if gopathenv == "" {

--- a/integration/_ignore/src/github.com/xoebus/prime/main.go
+++ b/integration/_ignore/src/github.com/xoebus/prime/main.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/xoebus/blacklist"
 	_ "github.com/xoebus/greylist-approve"
 	_ "github.com/xoebus/greylist-unknown"
+	_ "github.com/xoebus/nested/subdir"
 	_ "github.com/xoebus/no-license"
 	_ "github.com/xoebus/whitelist"
 )

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -41,6 +42,7 @@ var _ = Describe("Anderson", func() {
 
 		gopath, err := filepath.Abs(filepath.Join("_ignore"))
 		Ω(err).ShouldNot(HaveOccurred())
+		andersonCommand.Env = append(andersonCommand.Env, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
 		andersonCommand.Env = append(andersonCommand.Env, fmt.Sprintf("GOPATH=%s", gopath))
 	})
 
@@ -86,7 +88,7 @@ var _ = Describe("Anderson", func() {
 	It("handles dependencies that are in subdirectories of their root that contains the license", func() {
 		session := runAnderson()
 
-		Eventually(session).Should(Say("github.com/xoebus/nested/subdir.*CHECKS OUT"))
+		Eventually(session).Should(Say(`github.com/xoebus/nested[^/].*CHECKS OUT`)) // does not show subdir
 		Eventually(session).Should(Exit(1))
 	})
 })


### PR DESCRIPTION
shell out to `go list` instead. plus a bunch of magic to pretty-print
the resulting set of dependencies.

Signed-off-by: Ted Young tyoung@pivotallabs.com
