### PR TITLE
allow wildcards for greylisting packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ blacklist:
 - GPL
 
 exceptions:
-- github.com/xoebus/greylist
+- github.com/xoebus/explicitly_allowed
+- github.com/xoebus/greylist/*
 ```
 
-The whitelisted section is for licenses that are always allowed. Conversely,
-the blacklist section is for licenses that are never allowed and will always
-fail a build. Any licenses that are not explicitly mentioned are considered
-to be in a "greylist" and will need to be explicitly allowed by adding the
-import path to the exceptions.
+The whitelisted section is for licenses that are always allowed. Conversely, the
+blacklist section is for licenses that are never allowed and will always fail a
+build. Any licenses that are not explicitly mentioned are considered to be in a
+"greylist" and will need to be explicitly allowed by adding the import path to
+the exceptions. You can use wildcards (`*`) at the end of paths in the
+exceptions list to allow all nested packages under a top level path.
 

--- a/anderson/classifier.go
+++ b/anderson/classifier.go
@@ -45,7 +45,7 @@ func (c LicenseClassifier) classifyPath(path string, importPath string) (License
 	if err != nil {
 		switch err.Error() {
 		case license.ErrNoLicenseFile:
-			if contains(c.Config.Exceptions, importPath) {
+			if c.isException(importPath) {
 				return LicenseTypeAllowed, "Unknown", nil
 			}
 
@@ -69,7 +69,7 @@ func (c LicenseClassifier) classifyPath(path string, importPath string) (License
 		return LicenseTypeAllowed, l.Type, nil
 	}
 
-	if contains(c.Config.Exceptions, importPath) {
+	if c.isException(importPath) {
 		return LicenseTypeAllowed, l.Type, nil
 	}
 
@@ -89,6 +89,23 @@ func (c LicenseClassifier) parentPath(path string, hops int) string {
 	elements = append(elements, dots...)
 
 	return filepath.Clean(filepath.Join(elements...))
+}
+
+func (c LicenseClassifier) isException(importPath string) bool {
+	for _, exception := range c.Config.Exceptions {
+		if exception == importPath {
+			return true
+		}
+
+		if strings.HasSuffix(exception, "*") {
+			wildcard := strings.TrimRight(exception, "*")
+			if strings.HasPrefix(importPath, wildcard) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func contains(haystack []string, needle string) bool {

--- a/integration/_ignore/src/github.com/xoebus/greylist-wildcard/wildcard/doc.go
+++ b/integration/_ignore/src/github.com/xoebus/greylist-wildcard/wildcard/doc.go
@@ -1,0 +1,1 @@
+package wildcard

--- a/integration/_ignore/src/github.com/xoebus/prime/.anderson.yml
+++ b/integration/_ignore/src/github.com/xoebus/prime/.anderson.yml
@@ -7,3 +7,4 @@ blacklist:
 
 exceptions:
 - github.com/xoebus/greylist-approve
+- github.com/xoebus/greylist-wildcard/*

--- a/integration/_ignore/src/github.com/xoebus/prime/main.go
+++ b/integration/_ignore/src/github.com/xoebus/prime/main.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/xoebus/blacklist"
 	_ "github.com/xoebus/greylist-approve"
 	_ "github.com/xoebus/greylist-unknown"
+	_ "github.com/xoebus/greylist-wildcard/wildcard"
 	_ "github.com/xoebus/nested/subdir"
 	_ "github.com/xoebus/no-license"
 	_ "github.com/xoebus/prime/subdir"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -79,6 +79,20 @@ var _ = Describe("Anderson", func() {
 		Eventually(session).Should(Exit(1))
 	})
 
+	It("shows greylisted licences as 'CHECKS OUT'", func() {
+		session := runAnderson()
+
+		Eventually(session).Should(Say("github.com/xoebus/greylist-approve.*CHECKS OUT"))
+		Eventually(session).Should(Exit(1))
+	})
+
+	It("shows nested greylisted licences as 'CHECKS OUT' when a wildcard is used", func() {
+		session := runAnderson()
+
+		Eventually(session).Should(Say("github.com/xoebus/greylist-wildcard/wildcard.*CHECKS OUT"))
+		Eventually(session).Should(Exit(1))
+	})
+
 	It("shows projects with no license as 'NO LICENSE'", func() {
 		session := runAnderson()
 


### PR DESCRIPTION
I can see this being super handy for cases when you know that all packages within e.g. a given GitHub organisation will always be allowed.

I'm little unsure about the naming for the package I made in the test fixtures, but couldn't think of something better I'm afraid.
